### PR TITLE
jit-able scatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+datasets/qm9_dataset
+outputs/
+*/__pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+
+--find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+
+jax[cuda12]
+torch==2.1.0+cpu
+wandb
+hydra-core
+tqdm
+orbax
+flax
+pandas
+rdkit
+gpustat


### PR DESCRIPTION
qm9 training with padded particles (up to 29) and edges (up to 56) to make the training jit-able.
Given the average number of particles (18.0) and edges (37.3), this worst-case padding is still somewhat acceptable.

On a 48GB A6000 GPU one `train_epoch()` takes 57sec.

For an alternative implementation of the same idea, which we just tried out, check https://github.com/gerkone/ponita-jax

@ebekkers Ideas on how to validate the implementation? I just started a full run and will check the results tomorrow.